### PR TITLE
ComplexCalculation

### DIFF
--- a/BobTextureAnalysis_StreamlitApp.py
+++ b/BobTextureAnalysis_StreamlitApp.py
@@ -57,7 +57,7 @@ with col2:
 
         cropped = cropped_i[:cropped_i.shape[0] // chunk_size * chunk_size, :cropped_i.shape[1] // chunk_size * chunk_size]
         
-        coherence, two_phi = coh_ang_calc(cropped, sigma_outer=1, sigma_inner=1, epsilon=1e-6)
+        coherence, two_phi = coh_ang_calc(cropped)
 
         all_img = orient_hsv(cropped, coherence, two_phi, mode='all')
         coh_img = orient_hsv(cropped, coherence, two_phi, mode='coherence')

--- a/modules.py
+++ b/modules.py
@@ -52,7 +52,7 @@ def calculate_orientation(tensor):
     dominant_orientation = np.arctan2(eigvecs[1, 1], eigvecs[0, 1])  # Angle of the largest eigenvector
     return np.degrees(dominant_orientation)
 
-def coh_ang_calc(image, sigma_outer=1, sigma_inner=2, epsilon=1e-6):
+# def coh_ang_calc(image, sigma_outer=1, sigma_inner=2, epsilon=1e-6):
     chunk_size = 5
     assert len(image.shape) == 2, "Image should be 2d grayscale"
     # Initialize the HSV image
@@ -86,37 +86,44 @@ def coh_ang_calc(image, sigma_outer=1, sigma_inner=2, epsilon=1e-6):
 
     return coherence_img, angle_img
 
-def compute_structure_tensor(image, chunk_size=5, sigma=2):
-    grad_x = cv.Sobel(image, cv.CV_64F, 1, 0, ksize=3)
-    grad_y = cv.Sobel(image, cv.CV_64F, 0, 1, ksize=3)
-    
-    height, width = image.shape[:2]
-    tensor_list = []
-    gaussian_kernel = generate_gaussian_kernel(chunk_size, sigma)
-    
-    for y in range(0, height, chunk_size):
-        for x in range(0, width, chunk_size):
-            chunk_grad_x = grad_x[y:y + chunk_size, x:x + chunk_size]
-            chunk_grad_y = grad_y[y:y + chunk_size, x:x + chunk_size]
-            
-            J_xx = np.sum(chunk_grad_x ** 2 * gaussian_kernel)
-            J_yy = np.sum(chunk_grad_y ** 2 * gaussian_kernel)
-            J_xy = np.sum(chunk_grad_x * chunk_grad_y * gaussian_kernel)
-            
-            tensor_list.append(((x, y), np.array([[J_xx, J_xy], [J_xy, J_yy]])))
-    return tensor_list
 
-def calculate_orientation(tensor):
-    # lowkey just like self-explanitory lock in
-    _, eigvecs = np.linalg.eigh(tensor)  # Eigenvectors
-    dominant_orientation = np.arctan2(eigvecs[1, 1], eigvecs[0, 1])  # Angle of the largest eigenvector
-    return np.degrees(dominant_orientation)
+def sobel(image):
+    return cv.Sobel(image, cv.CV_64F, 1, 0, ksize=3), cv.Sobel(image, cv.CV_64F, 0, 1, ksize=3)
+
+def coh_ang_calc(image, gradient_calc=sobel, sigma_inner=1, epsilon=1e-6, kernel_radius=2):
+    # image: 2d grayscale image, perchance already mean downscaled a bit
+    # sigma_outer: sigma for gradient detection
+    # sigma_inner: sigma controlling bandwidth of angles detected
+    # epsilon: prevent div0 error for coherence
+    # kernel_radius: kernel size for gaussians - kernel will be 2*kernel_radius + 1 wide
+
+    # image gradient in x and y
+    I_x, I_y = gradient_calc(image)
+
+    # structure tensor
+    mu_20 = I_x ** 2
+    mu_02 = I_y ** 2
+    k_20_im = 2 * I_x * I_y # for later
+    del I_x, I_y
+
+    k_20_re = mu_20 - mu_02
+    k_11 = mu_20 + mu_02
+    del mu_20, mu_02
+
+    k_20_re = gaussian(k_20_re, sigma=sigma_inner, truncate=kernel_radius/sigma_inner)
+    k_20_im = gaussian(k_20_im, sigma=sigma_inner, truncate=kernel_radius/sigma_inner)
+    k_11 = gaussian(k_11, sigma=sigma_inner, truncate=kernel_radius/sigma_inner)
+
+    coherence = np.sqrt(k_20_re ** 2 + k_20_im ** 2) / (k_11 + epsilon)
+    orientation = np.arctan2(k_20_im, k_20_re)
+
+    return coherence, orientation
 
 def orient_hsv(image, coherence_image, angle_img, mode="all"):
 
     hsv_image = np.zeros((image.shape[0], image.shape[1], 3), dtype=np.float32)
     
-    hue_img = (angle_img % 180) / 180.0
+    hue_img = (angle_img % (np.pi * 2)) / (np.pi * 2)
 
     if mode == 'all':
         hsv_image[:, :, 0] = hue_img  # Hue: Orientation
@@ -127,6 +134,7 @@ def orient_hsv(image, coherence_image, angle_img, mode="all"):
         hsv_image[:, :, 0] = 0
         hsv_image[:, :, 1] = 0
         hsv_image[:, :, 2] = coherence_image # * np.mean(normalized_image[chunk_y, chunk_x])
+        
     elif mode == 'angle':
         hsv_image[:, :, 0] = hue_img  # Hue: Orientation
         hsv_image[:, :, 1] = 1
@@ -135,22 +143,10 @@ def orient_hsv(image, coherence_image, angle_img, mode="all"):
         assert False, "Invalid mode"
     
     # Gaussian blur so it looks nice
-    hsv_image[:, :, 0] = gaussian(hsv_image[:, :, 0], sigma=3)
-    hsv_image[:, :, 1] = gaussian(hsv_image[:, :, 1], sigma=3)
-    if mode == 'coherence':
-        hsv_image[:, :, 2] = gaussian(hsv_image[:, :, 2], sigma=3)
 
-    
     rgb_image = cv.cvtColor((hsv_image * 255).astype(np.uint8), cv.COLOR_HSV2RGB)
     return rgb_image
 
-def calculate_coherence(tensor):
-    # Eigenvalue-based coherence
-    eigvals, _ = np.linalg.eigh(tensor)
-    lambda1, lambda2 = eigvals  # Sorted eigenvalues (smallest first)
-    return np.abs((lambda1 - lambda2) / (lambda1 + lambda2 + 1e-5))
-    # np.abs((lambda1 - lambda2) / (lambda1 + lambda2 + 1e-5))
-    # return coherence # shouldnt coherence always be positive
 
 # TODO: fundamentally change coherence and orientation calculations: instead of breaking into
 # chunks, and then getting chunk-wide values, use this process:


### PR DESCRIPTION
Replaced calculation for coherence and angle, and removed unnecessary code. Former method broke image into chunks, and calculated eigenvalues of structure tensor for each chunk. Current method uses math from https://en.wikipedia.org/wiki/Structure_tensor to efficiently calculate coherence and angle per-pixel.